### PR TITLE
cp -r does not copy hidden files

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function getGitPostCmds(cfg) {
 }
 
 function getStaticPathCmds(staticpath) {
-  return staticpath ? ["cp -r " + staticpath + "/* ."] : [];
+  return staticpath ? ["cp -rT " + staticpath + "/ ."] : [];
 }
 
 function getCnameCmds(cname) {


### PR DESCRIPTION
I changed 
cp -r static/* 
to 
cp-rT staticpath/
to have hidden files (as .gitignore) copied also..